### PR TITLE
Initial setup for Deno/Vitest project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Short URL Service
+
+Initial setup using Deno and Vitest following Clean Architecture principles.
+
+## Scripts
+
+- `npm test` - run unit tests with Vitest.
+
+This project is intended to be run with Deno but uses Vitest for unit testing.

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "esnext"],
+    "strict": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "short-url",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^0.34.0"
+  }
+}

--- a/src/domain/url_repository.ts
+++ b/src/domain/url_repository.ts
@@ -1,0 +1,4 @@
+export interface UrlRepository {
+  save(url: string): Promise<string>;
+  find(short: string): Promise<string | null>;
+}

--- a/src/infra/memory_url_repository.ts
+++ b/src/infra/memory_url_repository.ts
@@ -1,0 +1,15 @@
+import { UrlRepository } from '../domain/url_repository.ts';
+
+export class MemoryUrlRepository implements UrlRepository {
+  private data = new Map<string, string>();
+
+  async save(url: string): Promise<string> {
+    const short = crypto.randomUUID().slice(0, 8);
+    this.data.set(short, url);
+    return short;
+  }
+
+  async find(short: string): Promise<string | null> {
+    return this.data.get(short) || null;
+  }
+}

--- a/src/usecase/shorten_url.ts
+++ b/src/usecase/shorten_url.ts
@@ -1,0 +1,9 @@
+import { UrlRepository } from '../domain/url_repository.ts';
+
+export class ShortenUrl {
+  constructor(private repository: UrlRepository) {}
+
+  async execute(url: string): Promise<string> {
+    return await this.repository.save(url);
+  }
+}

--- a/test/shorten_url.test.ts
+++ b/test/shorten_url.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { ShortenUrl } from '../src/usecase/shorten_url.ts';
+import { MemoryUrlRepository } from '../src/infra/memory_url_repository.ts';
+
+describe('ShortenUrl', () => {
+  it('returns shortened url and can retrieve original', async () => {
+    const repo = new MemoryUrlRepository();
+    const useCase = new ShortenUrl(repo);
+    const original = 'https://example.com';
+    const short = await useCase.execute(original);
+    expect(short).toBeDefined();
+    const found = await repo.find(short);
+    expect(found).toBe(original);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## Summary
- add basic project skeleton for a Deno based short URL service
- configure vitest for unit tests
- implement simple clean architecture structure

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684193e423748332afc5b8aa44044bad