### PR TITLE
Use Oak framework for API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@ Initial setup using Deno and Vitest following Clean Architecture principles.
 ## Scripts
 
 - `npm test` - run unit tests with Vitest.
+- `deno run --allow-net dev` - start the API server on port 8000 using Oak.
 
 This project is intended to be run with Deno but uses Vitest for unit testing.

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "esnext"],
+    "lib": [
+      "dom",
+      "esnext"
+    ],
     "strict": true
-  }
+  },
+  "importMap": "./import_map.json"
 }

--- a/import_map.json
+++ b/import_map.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "dev": "./src/server.ts"
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,34 @@
+import { Application, Router } from "https://deno.land/x/oak@v11.1.0/mod.ts";
+import { ShortenUrl } from "./usecase/shorten_url.ts";
+import { MemoryUrlRepository } from "./infra/memory_url_repository.ts";
+
+const repo = new MemoryUrlRepository();
+const useCase = new ShortenUrl(repo);
+
+const router = new Router();
+
+router
+  .post("/shorten", async (ctx) => {
+    const body = ctx.request.body({ type: "json" });
+    const { url: original } = await body.value;
+    const short = await useCase.execute(original);
+    ctx.response.headers.set("Content-Type", "application/json");
+    ctx.response.body = { short };
+  })
+  .get("/:short", async (ctx) => {
+    const short = ctx.params.short!;
+    const original = await repo.find(short);
+    if (original) {
+      ctx.response.type = "text/plain";
+      ctx.response.body = original;
+    } else {
+      ctx.response.status = 404;
+      ctx.response.body = "Not Found";
+    }
+  });
+
+const app = new Application();
+app.use(router.routes());
+app.use(router.allowedMethods());
+
+await app.listen({ port: 8000 });


### PR DESCRIPTION
## Summary
- replace HTTP server with Oak framework
- document Oak usage in README

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684196059a548332a82a97fc44a831b4