### PR TITLE
Add VSCode config for Deno projects

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "deno.enable": true,
+  "deno.lint": true,
+  "deno.unstable": false
+}


### PR DESCRIPTION
## Summary
- add `.vscode` folder with VSCode Deno settings so editors recognize this project as a Deno workspace

## Testing
- `deno test`


------
https://chatgpt.com/codex/tasks/task_e_6841a1d7872883329ea1395197b6e159