### PR TITLE
Add /count endpoint

### DIFF
--- a/src/domain/url_repository.ts
+++ b/src/domain/url_repository.ts
@@ -4,4 +4,6 @@ export interface UrlRepository {
   save(url: string): Promise<string>;
   // 短縮コードから元のURLを取得する
   find(short: string): Promise<string | null>;
+  // 保存されているURLの数を返す
+  count(): Promise<number>;
 }

--- a/src/infra/memory_url_repository.ts
+++ b/src/infra/memory_url_repository.ts
@@ -31,6 +31,11 @@ export class MemoryUrlRepository implements UrlRepository {
     return this.idToUrl.get(id) ?? null;
   }
 
+  // 保存されているURLの数を返す
+  async count(): Promise<number> {
+    return this.idToUrl.size;
+  }
+
   // 数値IDを62進数の文字列に変換する
   encode(num: number): string {
     if (num === 0) return BASE62[0];

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,11 @@ router
     ctx.response.type = "text/plain";
     ctx.response.body = "I'm Fine";
   })
+  .get("/count", async (ctx) => {
+    const count = await useCase.count();
+    ctx.response.headers.set("Content-Type", "application/json");
+    ctx.response.body = { count };
+  })
   .post("/shorten", async (ctx) => {
     const body = ctx.request.body({ type: "json" });
     const { url: original } = await body.value;

--- a/src/usecase/shorten_url.ts
+++ b/src/usecase/shorten_url.ts
@@ -11,4 +11,9 @@ export class ShortenUrl {
   async resolve(code: string): Promise<string | null> {
     return await this.repository.find(code);
   }
+
+  // 保存されているURLの数を返す
+  async count(): Promise<number> {
+    return await this.repository.count();
+  }
 }

--- a/test/shorten_url_test.ts
+++ b/test/shorten_url_test.ts
@@ -33,3 +33,15 @@ Deno.test("encode and decode numbers correctly", () => {
     assertEquals(repo.decode(code), i);
   }
 });
+
+// count メソッドが保存されているURL数を返すことを確認
+Deno.test("returns count of stored urls", async () => {
+  const repo = new MemoryUrlRepository();
+  const useCase = new ShortenUrl(repo);
+  const urls = ["https://a.com", "https://b.com"];
+  for (const url of urls) {
+    await useCase.execute(url);
+  }
+  const count = await useCase.count();
+  assertEquals(count, urls.length);
+});


### PR DESCRIPTION
## Summary
- add `count` to `UrlRepository`
- implement `count` in `MemoryUrlRepository`
- expose a `count` method in `ShortenUrl`
- add `/count` route to return number of stored URLs
- test the new functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841a29bd68c833294b734cf2d6e918f