### PR TITLE
Add MUI-based React frontend for shortening URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,17 @@ Initial setup using Deno following Clean Architecture principles.
 - `deno run --allow-net dev` - start the API server on port 8000 using Oak.
 
 This project is intended to be run with Deno.
+
+## Frontend
+
+A simple React + MUI UI is provided under `frontend/`. It allows you to input a URL and receive a shortened one from the running API.
+
+```
+# install dependencies (once)
+cd frontend && npm install
+
+# start development server
+npm run dev
+```
+
+The server proxy in Vite expects the API to be running on `http://localhost:8000`.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Short URL</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "short-url-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/material": "^5.15.5",
+    "axios": "^1.4.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.38",
+    "@types/react-dom": "^18.0.11",
+    "typescript": "^5.0.4",
+    "vite": "^4.3.9",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import axios from 'axios';
+import { Container, TextField, Button, Box, Typography } from '@mui/material';
+
+export default function App() {
+  const [url, setUrl] = useState('');
+  const [shortUrl, setShortUrl] = useState('');
+
+  const handleShorten = async () => {
+    if (!url) return;
+    try {
+      const res = await axios.post('/shorten', { url });
+      const code = res.data.short as string;
+      setShortUrl(`${window.location.origin}/${code}`);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <Container maxWidth="sm" sx={{ mt: 4 }}>
+      <Box display="flex" gap={2}>
+        <TextField
+          fullWidth
+          label="URL"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+        />
+        <Button variant="contained" onClick={handleShorten}>
+          Shorten
+        </Button>
+      </Box>
+      {shortUrl && (
+        <Typography variant="h6" sx={{ mt: 4 }}>
+          Short URL: <a href={shortUrl}>{shortUrl}</a>
+        </Typography>
+      )}
+    </Container>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+    proxy: {
+      '/shorten': 'http://localhost:8000'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- build a simple frontend under `frontend/` using React, TypeScript and MUI
- proxy API requests via Vite to the Deno backend
- document how to run the frontend in README

## Testing
- `deno test` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_684260b0dafc8332a57b0695edb7b675